### PR TITLE
refactor(security): cors 추가

### DIFF
--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/user/auth/config/SecurityConfig.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/user/auth/config/SecurityConfig.java
@@ -14,7 +14,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+import org.springframework.web.cors.CorsConfiguration;
 import xyz.tomorrowlearncamp.bookking.domain.user.enums.UserRole;
+
+import java.util.List;
 
 /**
  * 작성자 : 문성준
@@ -33,6 +36,16 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors
+                        .configurationSource(request -> {
+                            CorsConfiguration config = new CorsConfiguration();
+                            config.addAllowedOriginPattern("*");
+                            config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));
+                            config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+                            config.setAllowCredentials(true);
+                            return config;
+                        })
+                )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: bookKing
   profiles:
-    default: dev
+    default: release
 
 management:
   endpoint:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: bookKing
   profiles:
-    default: release
+    default: dev
 
 management:
   endpoint:


### PR DESCRIPTION
## 📌 PR 요약
- cors 추가

## 🔗 관련 이슈
- security 설정 (cors) #30

## 🛠️ 변경 사항
- cors 추가.
- 지금은 브라우저가 아닌 스웨거나 postman 같은 것들로 테스트하기 때문에 cors 체크 자체를 안하기 때문에 (cors 규칙 무시하고 직접 api 호출)  `origin = *` + `credentials = true` 로 구성. -> 추후 프론트 개발자 분이 붙어서 연다면, 그때 추가하면 된다고 판단했습니다.
