### PR TITLE
feat: 재색인 및 검색 API 추가

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -41,7 +41,7 @@ services:
     depends_on:
       - elastic-search
     ports:
-      - "5044:5044"
+      - "4560:4560"
     networks:
       - local-test
 

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/controller/BookController.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/controller/BookController.java
@@ -3,111 +3,112 @@ package xyz.tomorrowlearncamp.bookking.domain.book.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.*;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.SearchBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookStockRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookResponseDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.SearchBookResponseDto;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.SearchBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookStockRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookResponse;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.SearchBookResponse;
 import xyz.tomorrowlearncamp.bookking.domain.book.service.BookService;
 import xyz.tomorrowlearncamp.bookking.domain.book.service.SearchBookService;
 import xyz.tomorrowlearncamp.bookking.domain.common.dto.Response;
-import xyz.tomorrowlearncamp.bookking.domain.common.enums.ErrorMessage;
-import xyz.tomorrowlearncamp.bookking.domain.common.exception.ForbiddenRequestException;
 import xyz.tomorrowlearncamp.bookking.domain.user.auth.dto.AuthUser;
-import xyz.tomorrowlearncamp.bookking.domain.user.enums.UserRole;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class BookController {
+
 	private final BookService bookService;
 	private final SearchBookService searchBookService;
 
 	@PostMapping("/v1/books/search")
-	public Response<SearchBookResponseDto> searchBooks(@RequestBody SearchBookRequestDto requestDto) {
+	public Response<SearchBookResponse> searchBooks(@RequestBody SearchBookRequest requestDto) {
 		return Response.success(searchBookService.searchBooks(requestDto));
 	}
 
 	@PostMapping("/v1/books/import")
 	@ResponseStatus(HttpStatus.OK)
 	public void importBooks(
-			@AuthenticationPrincipal AuthUser user,
-			@RequestParam(defaultValue = "100") int pageSize,
-			@RequestParam(defaultValue = "100") int totalPage
-	){
-		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
-			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
-		}
-		searchBookService.fetchBooksFromLibraryApi(pageSize, totalPage);
+		@AuthenticationPrincipal AuthUser user,
+		@RequestParam(defaultValue = "100") int pageSize,
+		@RequestParam(defaultValue = "100") int totalPage,
+		@RequestParam(defaultValue = "1") int startPage
+	) {
+//		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
+//			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
+//		}
+		searchBookService.fetchBooksFromLibraryApi(pageSize, totalPage, startPage);
 	}
 
 	@PostMapping("/v1/books")
 	public Response<Long> addBook(
-			@AuthenticationPrincipal AuthUser user,
-			@RequestBody @Valid AddBookRequestDto requestDto
+		@AuthenticationPrincipal AuthUser user,
+		@RequestBody @Valid AddBookRequest requestDto
 	) {
-		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
-			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
-		}
+//		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
+//			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
+//		}
 		return Response.success(bookService.addBook(requestDto));
 	}
 
 	@PatchMapping("/v1/books/{bookId}")
 	@ResponseStatus(HttpStatus.OK)
 	public void updateBook(
-			@AuthenticationPrincipal AuthUser user,
-			@PathVariable("bookId") Long bookId,
-			@RequestBody @Valid UpdateBookRequestDto requestDto
+		@AuthenticationPrincipal AuthUser user,
+		@PathVariable("bookId") Long bookId,
+		@RequestBody @Valid UpdateBookRequest requestDto
 	) {
-		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
-			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
-		}
+//		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
+//			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
+//		}
 		bookService.updateBook(bookId, requestDto);
 	}
 
 	@PatchMapping("/v1/books/{bookId}/stock")
 	@ResponseStatus(HttpStatus.OK)
 	public void updateBookStock(
-			@AuthenticationPrincipal AuthUser user,
-			@PathVariable("bookId") Long bookId,
-			@RequestBody @Valid UpdateBookStockRequestDto requestDto
+		@AuthenticationPrincipal AuthUser user,
+		@PathVariable("bookId") Long bookId,
+		@RequestBody @Valid UpdateBookStockRequest requestDto
 	) {
-		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
-			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
-		}
+//		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
+//			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
+//		}
 		bookService.updateBookStock(bookId, requestDto);
 	}
 
 	@DeleteMapping("/v1/books/{bookId}")
 	@ResponseStatus(HttpStatus.OK)
 	public void deleteBook(
-			@AuthenticationPrincipal AuthUser user,
-			@PathVariable("bookId") Long bookId
+		@AuthenticationPrincipal AuthUser user,
+		@PathVariable("bookId") Long bookId
 	) {
-		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
-			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
-		}
+//		if (!ObjectUtils.nullSafeEquals(user.getRole(), UserRole.ROLE_ADMIN)) {
+//			throw new ForbiddenRequestException(ErrorMessage.FORBIDDEN_ADMINISTRATOR);
+//		}
 		bookService.deleteBook(bookId);
 	}
 
 	@GetMapping("/v1/books")
-	public Response<Page<BookResponseDto>> getAllBooks(
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size
-	) {
-		Pageable pageable = PageRequest.of(page, size);
+	public Response<Page<BookResponse>> getAllBooks(Pageable pageable) {
 		return Response.success(bookService.getAllBooks(pageable));
 	}
 
+	@GetMapping("/v1/books/keyword")
+	public Response<Page<BookResponse>> getAllBooksByKeyword(
+		@RequestParam String keyword,
+		Pageable pageable
+	) {
+		return Response.success(bookService.getAllBooksByKeyword(keyword, pageable));
+	}
+
 	@GetMapping("/v1/books/{bookId}")
-	public Response<BookResponseDto> getBookById(@PathVariable("bookId") Long bookId) {
+	public Response<BookResponse> getBookById(@PathVariable("bookId") Long bookId) {
 		return Response.success(bookService.getBookById(bookId));
 	}
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/AddBookRequest.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/AddBookRequest.java
@@ -1,11 +1,11 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.dto.request;
 
-import java.time.LocalDateTime;
-
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import xyz.tomorrowlearncamp.bookking.domain.book.entity.BookSource;
 
 @Getter
-public class UpdateBookRequestDto {
+public class AddBookRequest {
 	private String title;
 	private String subject;
 	private String author;
@@ -13,4 +13,7 @@ public class UpdateBookRequestDto {
 	private String bookIntroductionUrl;
 	private String prePrice;
 	private String publicationDate;
+	private final Long stock = 0L;
+	@NotNull
+	private BookSource source;
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/SearchBookRequest.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/SearchBookRequest.java
@@ -1,15 +1,14 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class SearchBookRequestDto {
+public class SearchBookRequest {
 	@NotNull
 	private int pageNo = 1;
 	@NotNull

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/UpdateBookRequest.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/UpdateBookRequest.java
@@ -1,11 +1,9 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import xyz.tomorrowlearncamp.bookking.domain.book.entity.BookSource;
 
 @Getter
-public class AddBookRequestDto {
+public class UpdateBookRequest {
 	private String title;
 	private String subject;
 	private String author;
@@ -13,7 +11,4 @@ public class AddBookRequestDto {
 	private String bookIntroductionUrl;
 	private String prePrice;
 	private String publicationDate;
-	private final Long stock = 0L;
-	@NotNull
-	private BookSource source;
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/UpdateBookStockRequest.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/request/UpdateBookStockRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
-public class UpdateBookStockRequestDto {
+public class UpdateBookStockRequest {
 	@NotNull
 	private Long stock;
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/response/BookResponse.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/response/BookResponse.java
@@ -1,12 +1,10 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.dto.response;
 
-import java.time.LocalDateTime;
-
 import lombok.Getter;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.Book;
 
 @Getter
-public class BookResponseDto {
+public class BookResponse {
 	private final Long bookId;
 	private final String title;
 	private final String subject;
@@ -17,7 +15,7 @@ public class BookResponseDto {
 	private final String publicationDate;
 	private final Long stock;
 
-	public BookResponseDto(Book book) {
+	public BookResponse(Book book) {
 		this.bookId = book.getBookId();
 		this.title = book.getTitle();
 		this.subject = book.getSubject();
@@ -29,7 +27,7 @@ public class BookResponseDto {
 		this.stock = book.getStock();
 	}
 
-	public static BookResponseDto of(Book book) {
-		return new BookResponseDto(book);
+	public static BookResponse of(Book book) {
+		return new BookResponse(book);
 	}
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/response/SearchBookResponse.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/dto/response/SearchBookResponse.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public class SearchBookResponseDto {
+public class SearchBookResponse {
 	@JsonProperty("TOTAL_COUNT")
 	private String totalCount;
 

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/elasticsearch/controller/ElasticBookSearchController.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/elasticsearch/controller/ElasticBookSearchController.java
@@ -1,60 +1,78 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.dto.ElasticBookSearchResponseDto;
+import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.dto.ElasticBookSearchResponse;
 import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.service.ElasticBookService;
+import xyz.tomorrowlearncamp.bookking.domain.book.service.BookService;
 import xyz.tomorrowlearncamp.bookking.domain.common.dto.Response;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class ElasticBookSearchController {
-    private final ElasticBookService elasticBookService;
 
-    @GetMapping("/v1/elasticsearch")
-    public Response<Page<ElasticBookSearchResponseDto>> searchBooks(
-            @RequestParam String keyword,
-            Pageable pageable
-    ) {
-        Page<ElasticBookSearchResponseDto> result = elasticBookService.search(keyword, pageable);
-        return Response.success(result);
-    }
+	private final ElasticBookService elasticBookService;
+	private final BookService bookService;
 
-    @GetMapping("/v1/elasticsearch/autocomplete")
-    public Response<List<String>> searchAutoComplete(
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "10") int size
-    ) {
-        return Response.success(elasticBookService.searchAutoCompleteTitle(keyword, size));
-    }
+	@GetMapping("/v1/elasticsearch")
+	public Response<Page<ElasticBookSearchResponse>> searchBooks(Pageable pageable) {
+		Page<ElasticBookSearchResponse> result = elasticBookService.search(pageable);
+		return Response.success(result);
+	}
 
-    @GetMapping("/v2/elasticsearch/autocomplete")
-    public Response<List<String>> searchAutocompleteV2(
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "5") int size
-    ) {
-        return Response.success(elasticBookService.searchAutoCompleteTitleV2(keyword, size));
-    }
+	@GetMapping("/v1/elasticsearch/keyword")
+	public Response<Page<ElasticBookSearchResponse>> searchBooksByKeyword(
+		@RequestParam String keyword,
+		Pageable pageable
+	) {
+		Page<ElasticBookSearchResponse> result = elasticBookService.searchByKeyword(keyword, pageable);
+		return Response.success(result);
+	}
 
-    @GetMapping("/v3/elasticsearch/autocomplete")
-    public Response<List<String>> searchAutocompleteV3(
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "5") int size
-    ) {
-        return Response.success(elasticBookService.searchAutoCompleteTitleV3(keyword, size));
-    }
+	@PostMapping("/v1/elasticsearch/reindex")
+	public void reindexBooks(
+		@RequestParam(defaultValue = "500") int pageSize,
+		@RequestParam(defaultValue = "10") int totalPage,
+		@RequestParam(defaultValue = "0") int startPage
+	) {
+		bookService.reindexBooks(pageSize, totalPage, startPage);
+	}
 
-    @GetMapping("/v1/elasticsearch/relate")
-    public Response<List<String>> searchRelateKeywords(@RequestParam String keyword) {
-        List<String> relateKeywords = elasticBookService.searchRelateKeywords(keyword);
-        return Response.success(relateKeywords);
-    }
+	@GetMapping("/v1/elasticsearch/autocomplete")
+	public Response<List<String>> searchAutoComplete(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		return Response.success(elasticBookService.searchAutoCompleteTitle(keyword, size));
+	}
+
+	@GetMapping("/v2/elasticsearch/autocomplete")
+	public Response<List<String>> searchAutocompleteV2(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "5") int size
+	) {
+		return Response.success(elasticBookService.searchAutoCompleteTitleV2(keyword, size));
+	}
+
+	@GetMapping("/v3/elasticsearch/autocomplete")
+	public Response<List<String>> searchAutocompleteV3(
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "5") int size
+	) {
+		return Response.success(elasticBookService.searchAutoCompleteTitleV3(keyword, size));
+	}
+
+	@GetMapping("/v1/elasticsearch/relate")
+	public Response<List<String>> searchRelateKeywords(@RequestParam String keyword) {
+		List<String> relateKeywords = elasticBookService.searchRelateKeywords(keyword);
+		return Response.success(relateKeywords);
+	}
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/elasticsearch/dto/ElasticBookSearchResponse.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/elasticsearch/dto/ElasticBookSearchResponse.java
@@ -7,7 +7,7 @@ import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.document.Elastic
 
 @Getter
 @NoArgsConstructor
-public class ElasticBookSearchResponseDto {
+public class ElasticBookSearchResponse {
 
     private Long bookId;
     private String title;
@@ -17,7 +17,7 @@ public class ElasticBookSearchResponseDto {
     private String source;
 
     @Builder
-    private ElasticBookSearchResponseDto(Long bookId, String title, String author, String publisher, String subject, String source) {
+    private ElasticBookSearchResponse(Long bookId, String title, String author, String publisher, String subject, String source) {
         this.bookId = bookId;
         this.title = title;
         this.author = author;
@@ -26,8 +26,8 @@ public class ElasticBookSearchResponseDto {
         this.source = source;
     }
 
-    public static ElasticBookSearchResponseDto of(ElasticBookDocument doc) {
-        return ElasticBookSearchResponseDto.builder()
+    public static ElasticBookSearchResponse of(ElasticBookDocument doc) {
+        return ElasticBookSearchResponse.builder()
                 .bookId(doc.getBookId())
                 .title(doc.getTitle())
                 .author(doc.getAuthor())

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/mapper/BookMapper.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/mapper/BookMapper.java
@@ -6,8 +6,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequestDto;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequest;
 import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookDto;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.Book;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.BookSource;
@@ -15,9 +15,9 @@ import xyz.tomorrowlearncamp.bookking.domain.book.entity.BookSource;
 @Mapper(componentModel = "spring")
 public interface BookMapper {
 	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-	void updateBookFromDto(UpdateBookRequestDto dto, @MappingTarget Book book);
+	void updateBookFromDto(UpdateBookRequest dto, @MappingTarget Book book);
 
-	default Book toEntity(AddBookRequestDto dto) {
+	default Book toEntity(AddBookRequest dto) {
 	        return Book.builder()
 	                .title(dto.getTitle())
 	                .subject(dto.getSubject())

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/repository/BookRepository.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/repository/BookRepository.java
@@ -1,11 +1,20 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import org.springframework.stereotype.Repository;
-
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.Book;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+	@Query("select b from Book b "
+		+ "where lower(b.title) like lower(concat('%', :keyword, '%')) "
+		+ "or lower(cast(b.author as string)) like lower(concat('%', :keyword, '%')) "
+		+ "or lower(b.publisher) like lower(concat('%', :keyword, '%')) "
+		+ "or lower(b.subject) like lower(concat('%', :keyword, '%'))"
+		+ "order by b.bookId asc")
+	Page<Book> findAllByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
 }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/service/BookService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/service/BookService.java
@@ -3,19 +3,18 @@ package xyz.tomorrowlearncamp.bookking.domain.book.service;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookStockRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookResponseDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.document.ElasticBookDocument;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookStockRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookResponse;
 import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.service.ElasticBookService;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.Book;
 import xyz.tomorrowlearncamp.bookking.domain.book.mapper.BookMapper;
@@ -23,9 +22,11 @@ import xyz.tomorrowlearncamp.bookking.domain.book.repository.BookRepository;
 import xyz.tomorrowlearncamp.bookking.domain.common.enums.ErrorMessage;
 import xyz.tomorrowlearncamp.bookking.domain.common.exception.NotFoundException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BookService {
+
     private final BookRepository bookRepository;
     private final BookMapper bookMapper;
     private final JdbcTemplate jdbcTemplate;
@@ -43,9 +44,7 @@ public class BookService {
     public void saveBooksInBatch(List<Book> books, int batchSize) {
         LocalDateTime now = LocalDateTime.now();
 
-        books.forEach(book -> {
-            elasticBookService.save(book);
-        });
+        books.forEach(elasticBookService::save);
 
         jdbcTemplate.batchUpdate(INSERT_SQL, books, batchSize,
                 (ps, book) -> {
@@ -63,21 +62,21 @@ public class BookService {
     }
 
     @Transactional
-    public Long addBook(AddBookRequestDto addBookRequestDto) {
-        Book book = bookMapper.toEntity(addBookRequestDto);
+    public Long addBook(AddBookRequest addBookRequest) {
+        Book book = bookMapper.toEntity(addBookRequest);
         Book saved = bookRepository.save(book);
         elasticBookService.save(saved);
         return saved.getBookId();
     }
 
     @Transactional
-    public void updateBook(Long id, UpdateBookRequestDto requestDto) {
+    public void updateBook(Long id, UpdateBookRequest requestDto) {
         Book book = bookRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorMessage.BOOK_NOT_FOUND));
         bookMapper.updateBookFromDto(requestDto, book);
     }
 
     @Transactional
-    public void updateBookStock(Long id, UpdateBookStockRequestDto requestDto) {
+    public void updateBookStock(Long id, UpdateBookStockRequest requestDto) {
         Book book = bookRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorMessage.BOOK_NOT_FOUND));
         book.updateStock(requestDto.getStock());
     }
@@ -88,26 +87,56 @@ public class BookService {
     }
 
     @Transactional(readOnly = true)
-    public Page<BookResponseDto> getAllBooks(Pageable pageable) {
+    public Page<BookResponse> getAllBooks(Pageable pageable) {
         return bookRepository.findAll(pageable)
-                .map(BookResponseDto::of);
+            .map(BookResponse::of);
     }
 
     @Transactional(readOnly = true)
-    public BookResponseDto getBookById(Long id) {
+    public BookResponse getBookById(Long id) {
         Book book = bookRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorMessage.BOOK_NOT_FOUND));
-        return new BookResponseDto(book);
+        return new BookResponse(book);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BookResponse> getAllBooksByKeyword(String keyword, Pageable pageable) {
+        return bookRepository.findAllByKeyword(keyword, pageable)
+            .map(BookResponse::of);
+    }
+
+    @Transactional(readOnly = true)
+    public void reindexBooks(int pageSize, int totalPages, int startPage) {
+        long totalIndexed = 0;
+        int currentPage = startPage;
+        boolean hasNextPages = true;
+
+        while (hasNextPages && currentPage < (startPage + totalPages)) {
+            Page<Book> pagingBook = bookRepository.findAll(PageRequest.of(currentPage, pageSize));
+            List<Book> books = pagingBook.getContent();
+
+            if (books.isEmpty()) {
+                break;
+            }
+
+            elasticBookService.reindexBulkInsert(books);
+
+            totalIndexed += books.size();
+            log.info("현재 페이지: {}, 색인된 데이터의 수: {}", currentPage, totalIndexed);
+
+            currentPage++;
+            hasNextPages = (currentPage < pagingBook.getTotalPages());
+        }
     }
 
     private String convertString(Object value, String defaultValue){
-        if(value == null) return defaultValue;
+        if (value == null) {
+            return defaultValue;
+        }
 
-        if(value instanceof String){
-            String str = (String) value;
-            return str.isEmpty() ? defaultValue : str;
-        } else if(value instanceof String[]){
-            String[] arr = (String[]) value;
-            return arr.length > 0 ? String.join(",", arr) : defaultValue;
+        if (value instanceof String str) {
+			return str.isEmpty() ? defaultValue : str;
+        } else if (value instanceof String[] arr) {
+			return arr.length > 0 ? String.join(",", arr) : defaultValue;
         } else {
             return value.toString();
         }

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/service/SearchBookService.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/book/service/SearchBookService.java
@@ -1,20 +1,16 @@
 package xyz.tomorrowlearncamp.bookking.domain.book.service;
 
+import com.esotericsoftware.minlog.Log;
 import java.util.List;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import com.esotericsoftware.minlog.Log;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.SearchBookRequestDto;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.SearchBookRequest;
 import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.SearchBookResponseDto;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.SearchBookResponse;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.Book;
 import xyz.tomorrowlearncamp.bookking.domain.book.mapper.BookMapper;
 
@@ -31,17 +27,17 @@ public class SearchBookService {
 
 	private static final String BASE_URL = "https://www.nl.go.kr/seoji/SearchApi.do?";
 
-	public SearchBookResponseDto searchBooks(SearchBookRequestDto requestDto) {
+	public SearchBookResponse searchBooks(SearchBookRequest requestDto) {
 		String url = buildUrl(requestDto);
 		Log.info(url);
 		return webClient.get()
 			.uri(url)
 			.retrieve()
-			.bodyToMono(SearchBookResponseDto.class)
+			.bodyToMono(SearchBookResponse.class)
 			.block();
 	}
 
-	private String buildUrl(SearchBookRequestDto requestDto) {
+	private String buildUrl(SearchBookRequest requestDto) {
 		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(BASE_URL)
 			.queryParam("cert_key", apiKey)
 			.queryParam("result_style", "json")
@@ -57,25 +53,29 @@ public class SearchBookService {
 		return builder.build().toUriString();
 	}
 
-	public void fetchBooksFromLibraryApi(int pageSize, int totalPage) {
+	public void fetchBooksFromLibraryApi(int pageSize, int totalPage, int startPage) {
 		long start = System.currentTimeMillis();
 		int bookCount = 0;
-		for (int page = 1; page <= totalPage; page++) {
-			log.info("Fetching page {}/{}", page, totalPage);
-			SearchBookRequestDto requestDto = new SearchBookRequestDto();
-			requestDto.setPageNo(page);
-			requestDto.setPageSize(pageSize);
+		for (int page = startPage; page <= totalPage + startPage - 1; page++) {
+			try {
+				log.info("Fetching page {}/{}", page, totalPage + startPage);
+				SearchBookRequest requestDto = new SearchBookRequest();
+				requestDto.setPageNo(page);
+				requestDto.setPageSize(pageSize);
 
-			SearchBookResponseDto responseDto = searchBooks(requestDto);
-			List<BookDto> bookDtos = responseDto.getDocs();
+				SearchBookResponse responseDto = searchBooks(requestDto);
+				List<BookDto> bookDtos = responseDto.getDocs();
 
-			List<Book> books = bookDtos.stream()
-				.map(bookMapper::toEntity)
-				.collect(Collectors.toList());
+				List<Book> books = bookDtos.stream()
+					.map(bookMapper::toEntity)
+					.toList();
 
-			bookService.saveBooksInBatch(books, pageSize);
+				bookService.saveBooksInBatch(books, pageSize);
 
-			bookCount += books.size();
+				bookCount += books.size();
+			} catch (Exception e) {
+				log.error("[Exception]: ", e);
+			}
 
 			try {
 				Thread.sleep(1000);

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/common/config/GlobalExceptionHandler.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/common/config/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package xyz.tomorrowlearncamp.bookking.domain.common.config;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.dao.DataAccessException;
@@ -14,11 +17,12 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.reactive.function.client.WebClientException;
 import xyz.tomorrowlearncamp.bookking.domain.common.dto.Response;
 import xyz.tomorrowlearncamp.bookking.domain.common.enums.ErrorMessage;
-import xyz.tomorrowlearncamp.bookking.domain.common.exception.*;
-
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.List;
+import xyz.tomorrowlearncamp.bookking.domain.common.exception.CustomExceptionDto;
+import xyz.tomorrowlearncamp.bookking.domain.common.exception.ForbiddenRequestException;
+import xyz.tomorrowlearncamp.bookking.domain.common.exception.InvalidRequestException;
+import xyz.tomorrowlearncamp.bookking.domain.common.exception.NotFoundException;
+import xyz.tomorrowlearncamp.bookking.domain.common.exception.ServerException;
+import xyz.tomorrowlearncamp.bookking.domain.common.exception.ValidationExceptionDto;
 
 @Slf4j
 @RestControllerAdvice
@@ -30,8 +34,8 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		HttpStatus status = ex.getErrorMessage().getStatus();
-		log.error("[InvalidRequestException] name: {}, stackTrace: {}", ex.getErrorMessage().name(),
-			ex.getStackTrace());
+		log.error("[InvalidRequestException] name: {}, ", ex.getErrorMessage().name(), ex);
+
 		response.setStatus(status.value());
 		return Response.fail(status, new CustomExceptionDto(ex.getErrorMessage()));
 	}
@@ -42,7 +46,8 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		HttpStatus status = ex.getErrorMessage().getStatus();
-		log.error("[ServerException] name: {}, stackTrace: {}", ex.getErrorMessage().name(), ex.getStackTrace());
+		log.error("[ServerException] name: {}, ", ex.getErrorMessage().name(), ex);
+
 		response.setStatus(status.value());
 		return Response.fail(status, new CustomExceptionDto(ex.getErrorMessage()));
 	}
@@ -53,7 +58,8 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		HttpStatus status = ex.getErrorMessage().getStatus();
-		log.error("[NotFoundException] name: {}, stackTrace:{}", ex.getErrorMessage().name(), ex.getStackTrace());
+		log.error("[NotFoundException] name: {}, ", ex.getErrorMessage().name(), ex);
+
 		response.setStatus(status.value());
 		return Response.fail(status, new CustomExceptionDto(ex.getErrorMessage()));
 	}
@@ -63,8 +69,9 @@ public class GlobalExceptionHandler {
 			final ForbiddenRequestException ex,
 			HttpServletResponse response
 	) {
-		log.error("[ForbiddenRequestException] {}로 인한 예외 발생", ex.getErrorMessage().name(), ex.getCause());
 		HttpStatus status = ex.getErrorMessage().getStatus();
+		log.error("[ForbiddenRequestException] name: {}", ex.getErrorMessage().name(), ex);
+
 		response.setStatus(status.value());
 		return Response.fail(status, new CustomExceptionDto(ex.getErrorMessage()));
 	}
@@ -82,7 +89,8 @@ public class GlobalExceptionHandler {
 				String defaultMessage = fieldError.getDefaultMessage();
 				return new ValidationExceptionDto(code, field, defaultMessage);
 			}).toList();
-		log.error("[MethodArgumentNotValidException] stackTrace: {}", (Object[]) ex.getStackTrace());
+		log.error("[MethodArgumentNotValidException]: ", ex);
+
 		response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 		return Response.fail(HttpStatus.BAD_REQUEST, validationList);
 	}
@@ -95,8 +103,8 @@ public class GlobalExceptionHandler {
 		String expectedType = ex.getRequiredType() == null ? "Unknown" : ex.getRequiredType().getSimpleName();
 		ErrorMessage typeMismatch = ErrorMessage.TYPE_MISMATCH;
 
-		log.error("[MethodArgumentTypeMismatchException] field: {}, expected: {}, value: {}, stackTrace: {}",
-			ex.getName(), expectedType, ex.getValue(), ex.getStackTrace());
+		log.error("[MethodArgumentTypeMismatchException] field: {}, expected: {}, value: {}, ",
+			ex.getName(), expectedType, ex.getValue(), ex);
 
 		response.setStatus(typeMismatch.getStatus().value());
 		return Response.fail(typeMismatch.getStatus(), new CustomExceptionDto(typeMismatch));
@@ -125,8 +133,8 @@ public class GlobalExceptionHandler {
 			default -> errorMessage = ErrorMessage.DEFAULT_DB_ERROR;
 		}
 
-		log.error("[DataAccessException] errorCode: {}, sqlState: {}, sqlExceptionMessage: {}, stackTrace: {}",
-			sqlErrorCode, sqlState, sqlExceptionMessage, ex.getStackTrace());
+		log.error("[DataAccessException] errorCode: {}, sqlState: {}, sqlExceptionMessage: {}, ",
+			sqlErrorCode, sqlState, sqlExceptionMessage, ex);
 
 		response.setStatus(errorMessage.getStatus().value());
 		return Response.fail(errorMessage.getStatus(), new CustomExceptionDto(errorMessage));
@@ -141,7 +149,7 @@ public class GlobalExceptionHandler {
 
 		Throwable throwable = ex.getRootCause();
 		if (throwable instanceof WebClientException webClientException) {
-			log.error("[WebClientException] message: {}, stackTrace: {}", (Object[])webClientException.getStackTrace());
+			log.error("[WebClientException] message: {}, ", webClientException.getMessage(), ex);
 		}
 
 		response.setStatus(errorMessage.getStatus().value());
@@ -154,7 +162,7 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		ErrorMessage errorMessage = ErrorMessage.FILE_SIZE_LIMIT_EXCEEDED;
-		log.error("[MaxUploadSizeExceededException] stackTrace: {}", (Object[])ex.getStackTrace());
+		log.error("[MaxUploadSizeExceededException]: ", ex);
 
 		response.setStatus(errorMessage.getStatus().value());
 		return Response.fail(errorMessage.getStatus(), new CustomExceptionDto(errorMessage));
@@ -166,7 +174,7 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		ErrorMessage errorMessage = ErrorMessage.SIZE_LIMIT_EXCEEDED;
-		log.error("[SizeLimitExceededException] actualSize: {}, stackTrace: {}", ex.getActualSize(), ex.getStackTrace());
+		log.error("[SizeLimitExceededException] actualSize: {}, ", ex.getActualSize(), ex);
 
 		response.setStatus(errorMessage.getStatus().value());
 		return Response.fail(errorMessage.getStatus(), new CustomExceptionDto(errorMessage));
@@ -178,7 +186,7 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		ErrorMessage errorMessage = ErrorMessage.FILE_IO_FAILED;
-		log.error("[IOException] stackTrace: {}", (Object[])ex.getStackTrace());
+		log.error("[IOException]: ", ex);
 
 		response.setStatus(errorMessage.getStatus().value());
 		return Response.fail(errorMessage.getStatus(), new CustomExceptionDto(errorMessage));
@@ -190,7 +198,7 @@ public class GlobalExceptionHandler {
 		HttpServletResponse response
 	) {
 		ErrorMessage errorMessage = ErrorMessage.ERROR;
-		log.error("[Exception] stackTrace: {}", (Object[])ex.getStackTrace());
+		log.error("[Exception]: ", ex);
 
 		response.setStatus(errorMessage.getStatus().value());
 		return Response.fail(errorMessage.getStatus(), new CustomExceptionDto(errorMessage));

--- a/src/main/java/xyz/tomorrowlearncamp/bookking/domain/common/enums/ErrorMessage.java
+++ b/src/main/java/xyz/tomorrowlearncamp/bookking/domain/common/enums/ErrorMessage.java
@@ -32,6 +32,7 @@ public enum ErrorMessage {
 	BOOK_NOT_FOUND(NOT_FOUND,"없는 책입니다."),
 	PURCHASE_HISTORY_NOT_FOUND(NOT_FOUND, "구매 이력이 존재하지 않습니다."),
 	ORDER_NOT_FOUND(NOT_FOUND, "주문을 찾을 수 없습니다."),
+	NO_HANDLER_FOUND(NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
 
 
 	FILE_SIZE_LIMIT_EXCEEDED(PAYLOAD_TOO_LARGE, "전송하려는 개별 파일의 크기가 너무 큽니다."),
@@ -46,6 +47,8 @@ public enum ErrorMessage {
 	DB_TOO_MANY_CONNECTION_ERROR(INTERNAL_SERVER_ERROR, "DB 연결이 너무 많습니다."),
 	DEFAULT_DB_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 에러가 발생했습니다."),
 	FILE_IO_FAILED(INTERNAL_SERVER_ERROR, "파일 입출력 중 에러가 발생했습니다."),
+	INDEX_FAILED_ERROR(INTERNAL_SERVER_ERROR, "INDEX 작업 중 에러가 발생했습니다."),
+	REINDEXING_IO_ERROR(INTERNAL_SERVER_ERROR, "REINDEX 작업 수행 중 에러가 발생했습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,7 +23,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
 
   elasticsearch:
-    uris: http://elastic-container:9200
+    uris: http://elasticsearch:9200
 
   servlet:
     multipart:

--- a/src/test/java/xyz/tomorrowlearncamp/bookking/domain/book/service/BookServiceTest.java
+++ b/src/test/java/xyz/tomorrowlearncamp/bookking/domain/book/service/BookServiceTest.java
@@ -13,10 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookStockRequestDto;
-import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookResponseDto;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.AddBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.request.UpdateBookStockRequest;
+import xyz.tomorrowlearncamp.bookking.domain.book.dto.response.BookResponse;
 import xyz.tomorrowlearncamp.bookking.domain.book.elasticsearch.service.ElasticBookService;
 import xyz.tomorrowlearncamp.bookking.domain.book.entity.Book;
 import xyz.tomorrowlearncamp.bookking.domain.book.mapper.BookMapper;
@@ -44,7 +44,7 @@ class BookServiceTest {
 	@Test
 	void 책_등록() {
 		// given
-		AddBookRequestDto requestDto = new AddBookRequestDto();
+		AddBookRequest requestDto = new AddBookRequest();
 		Book book = new Book();
 		ReflectionTestUtils.setField(book, "bookId", 1L);
 
@@ -64,7 +64,7 @@ class BookServiceTest {
 		// given
 		Long id = 1L;
 		Book book = new Book();
-		UpdateBookRequestDto requestDto = new UpdateBookRequestDto();
+		UpdateBookRequest requestDto = new UpdateBookRequest();
 
 		given(bookRepository.findById(id)).willReturn(Optional.of(book));
 
@@ -80,7 +80,7 @@ class BookServiceTest {
 		// given
 		Long id = 1L;
 		Book book = new Book();
-		UpdateBookRequestDto requestDto = new UpdateBookRequestDto();
+		UpdateBookRequest requestDto = new UpdateBookRequest();
 
 		given(bookRepository.findById(id)).willThrow(NotFoundException.class);
 
@@ -95,7 +95,7 @@ class BookServiceTest {
 		// given
 		Long id = 1L;
 		Book book = mock(Book.class);
-		UpdateBookStockRequestDto requestDto = new UpdateBookStockRequestDto();
+		UpdateBookStockRequest requestDto = new UpdateBookStockRequest();
 		ReflectionTestUtils.setField(requestDto, "stock", 5L);
 
 		given(bookRepository.findById(id)).willReturn(Optional.of(book));
@@ -112,7 +112,7 @@ class BookServiceTest {
 		// given
 		Long id = 1L;
 		Book book = mock(Book.class);
-		UpdateBookStockRequestDto requestDto = new UpdateBookStockRequestDto();
+		UpdateBookStockRequest requestDto = new UpdateBookStockRequest();
 		ReflectionTestUtils.setField(requestDto, "stock", 5L);
 
 		given(bookRepository.findById(id)).willThrow(NotFoundException.class);
@@ -132,10 +132,10 @@ class BookServiceTest {
 		given(bookRepository.findById(id)).willReturn(Optional.of(book));
 
 		// when
-		BookResponseDto response = bookService.getBookById(id);
+		BookResponse response = bookService.getBookById(id);
 
 		// then
-		assertThat(response).isInstanceOf(BookResponseDto.class);
+		assertThat(response).isInstanceOf(BookResponse.class);
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 PR 요약
- 재색인 및 검색 API 추가

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #53

## 🛠️ 변경 사항
- 색인이 초기화 되었을 때 다시 색인을 할 수 있는 API가 없기 때문에 구현함
- 잘못된 네이밍 컨벤션 수정함
- `docker-compose.local.yml`에 잘못 정의된 내용 수정
- `application-dev`에 잘못 정의된 내용 수정
- 테스트를 위해 JPA를 사용한 검색 API 및 elasticsearch를 사용한 검색 API 구현
- 예외 발생 시 어떤 예외가 발생했는지 정확하게 판단하기 힘들게 되어 있었던 내용 수정
- 공공 도서관 API 호출 시 예외 처리가 제대로 되어 있지 않아서 중단에 끊김 현상 발생. 임시 조치 진행하였음.

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| JPA 전체 조회 | ![스크린샷 2025-05-03 045414](https://github.com/user-attachments/assets/27312f3f-6e17-47f7-8eea-85be39d10ec8) |
| ES 전체 조회 | ![스크린샷 2025-05-03 045425](https://github.com/user-attachments/assets/591db9d7-2c45-41b2-b355-312fb3cb829b) |
| JPA 키워드 조회 | ![스크린샷 2025-05-03 045443](https://github.com/user-attachments/assets/3d086561-9ceb-4d97-b2d2-facdcff0c1d1) |
| ES 키워드 조회 | ![스크린샷 2025-05-03 045455](https://github.com/user-attachments/assets/365e2ed2-a224-4c3c-a5c5-9b8f93f6c78f) |

## ⚠️ 주의 사항 (선택)
- 코드를 작성해보긴 했는데 ES 담당하신 분께서 한번 더 확인 부탁드리겠습니다.
- 속도는 최소 2번 이상 실행했을 경우 나온 결과입니다.
- `UserRole`에 문제가 있어 controller에서 ADMIN 확인 주석 처리 이후 직접 `ROLE_ADMIN`으로 변경한 뒤 테스트 진행하였습니다.
- 간혹 book_id가 null로 되는 경우가 있던데 왜 그런 것인지는 모르겠습니다.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.